### PR TITLE
needed for rhel 6 & 7

### DIFF
--- a/check_tcptraffic.spec
+++ b/check_tcptraffic.spec
@@ -20,6 +20,7 @@ Source:    https://github.com/matteocorti/%{sourcename}/releases/download/v%{ver
 
 # Fedora build requirement (not needed for EPEL{4,5})
 BuildRequires: perl(ExtUtils::MakeMaker)
+BuildRequires: perl-Module-Install
 
 Requires:  nagios-plugins
 


### PR DESCRIPTION
Hello,

additional BuildRequires is needed for succesful Build on RHEL 6 and RHEL 7
